### PR TITLE
DC Bill Introducers

### DIFF
--- a/openstates/dc/bills.py
+++ b/openstates/dc/bills.py
@@ -77,18 +77,25 @@ class DCBillScraper(BillScraper):
                 bill = Bill(session,"upper", bill_id, title, type=bill_type)
 
                 #sponsors and cosponsors
-                try:
-                    #sometimes there are sponsors, sometimes not.
+                if "Introducer" in legislation_info:
                     introducers = legislation_info["Introducer"]
-                except KeyError:
+                    intro_date = self.date_format(legislation_info["IntroductionDate"])
+                    bill.add_action("upper",
+                                    "Introduced",
+                                    intro_date,
+                                    type="bill:introduced")
+                else:
+                    #sometimes there are introducers, sometimes not.
+                    # Set Introducers to empty array to avoid downstream breakage, but log bills without introducers
+                    self.logger.warning("No Introducer: {0} {1}: {2}".format(bill['chamber'], bill['session'], bill['bill_id']))
                     introducers = []
-                
+
                 try:
                     #sometimes there are cosponsors, sometimes not.
                     cosponsors = legislation_info["CoSponsor"]
                 except KeyError:
                     cosponsors = []
-                    
+
                 for i in introducers:
                     sponsor_name = i["Name"]
                     #they messed up Phil Mendelson's name

--- a/openstates/dc/bills.py
+++ b/openstates/dc/bills.py
@@ -38,7 +38,44 @@ class DCBillScraper(BillScraper):
         headers = {"Content-Type":"application/json"}
         url = "http://lims.dccouncil.us/_layouts/15/uploader/AdminProxy.aspx/GetPublicAdvancedSearch"
         bill_url = "http://lims.dccouncil.us/_layouts/15/uploader/AdminProxy.aspx/GetPublicData"
-        params = {"request":{"sEcho":2,"iColumns":4,"sColumns":"","iDisplayStart":0,"iDisplayLength":per_page,"mDataProp_0":"ShortTitle","mDataProp_1":"Title","mDataProp_2":"LegislationCategories","mDataProp_3":"Modified","iSortCol_0":0,"sSortDir_0":"asc","iSortingCols":0,"bSortable_0":"true","bSortable_1":"true","bSortable_2":"true","bSortable_3":"true"},"criteria":{"Keyword":"","Category":"","SubCategoryId":"","RequestOf":"","CouncilPeriod":str(session),"Introducer":"","CoSponsor":"","CommitteeReferral":"","CommitteeReferralComments":"","StartDate":"","EndDate":"","QueryLimit":100,"FilterType":"","Phases":"","LegislationStatus":"0","IncludeDocumentSearch":"false"}}
+        params = {
+            "request": {
+                "sEcho":2,
+                "iColumns":4,
+                "sColumns":"",
+                "iDisplayStart":0,
+                "iDisplayLength":per_page,
+                "mDataProp_0":"ShortTitle",
+                "mDataProp_1":"Title",
+                "mDataProp_2":"LegislationCategories",
+                "mDataProp_3":"Modified",
+                "iSortCol_0":0,
+                "sSortDir_0":"asc",
+                "iSortingCols":0,
+                "bSortable_0":"true",
+                "bSortable_1":"true",
+                "bSortable_2":"true",
+                "bSortable_3":"true"
+            },
+            "criteria":{
+                "Keyword":"",
+                "Category":"",
+                "SubCategoryId":"",
+                "RequestOf":"",
+                "CouncilPeriod":str(session),
+                "Introducer":"",
+                "CoSponsor":"",
+                "CommitteeReferral":"",
+                "CommitteeReferralComments":"",
+                "StartDate":"",
+                "EndDate":"",
+                "QueryLimit":100,
+                "FilterType":"",
+                "Phases":"",
+                "LegislationStatus":"0",
+                "IncludeDocumentSearch":"false"
+            }
+        }
         param_json = json.dumps(params)
         response = self.post(url,headers=headers,data=param_json)
         #the response is a terrible string-of-nested-json-strings. Yuck.


### PR DESCRIPTION
Update DC scraper to include bill introduction action.

Implemented to address missing introducution metadata in [B21-0774](http://lims.dccouncil.us/Legislation/B21-0774) but should affect other bills that were missing this metadata.